### PR TITLE
Use 99-sysctl.conf instead

### DIFF
--- a/content/documents/level-0/ch07-xray-server.md
+++ b/content/documents/level-0/ch07-xray-server.md
@@ -393,7 +393,7 @@ weight: 7
 
     4. 修改`sysctl.conf`开启`BBR`
         ```
-        $ sudo nano /etc/sysctl.conf
+        $ sudo nano /etc/sysctl.d/99-sysctl.conf
         ```
 
     5. 把下面的内容添加进去


### PR DESCRIPTION
目前，版本高于207的systemd忽略了 /etc/sysctl.conf ，而 sysctl.d 目录下的文件始终有效

Currently, systemd whose versions higher than 207 ignore /etc/sysctl.conf and the configuration files in the sysctl.d directory are always effective