### PR TITLE
修正使用自定义字符串映射UUID的命令选项

### DIFF
--- a/content/config/inbound-protocols/vless.md
+++ b/content/config/inbound-protocols/vless.md
@@ -77,7 +77,7 @@ VLESS 的用户 ID，可以是任意小于30字节的字符串, 也可以是一�
  
 其映射标准在[VLESS UUID 映射标准：将自定义字符串映射为一个 UUIDv5](https://github.com/XTLS/Xray-core/issues/158)
 
-你可以使用命令 `xray uuid -map "自定义字符串"` 生成自定义字符串所映射的的 UUID.</br> 
+你可以使用命令 `xray uuid -i "自定义字符串"` 生成自定义字符串所映射的的 UUID.</br>
 也可以使用命令 `xray uuid` 生成随机的UUID. 
 
 {{% notice dark %}} `level`: number{{% /notice %}}

--- a/content/config/inbound-protocols/vmess.md
+++ b/content/config/inbound-protocols/vmess.md
@@ -81,7 +81,7 @@ Vmess 的用户 ID，可以是任意小于30字节的字符串, 也可以是一�
  
 其映射标准在[VLESS UUID 映射标准：将自定义字符串映射为一个 UUIDv5](https://github.com/XTLS/Xray-core/issues/158)
 
-你可以使用命令 `xray uuid -map "自定义字符串"` 生成自定义字符串所映射的的 UUID.</br> 
+你可以使用命令 `xray uuid -i "自定义字符串"` 生成自定义字符串所映射的的 UUID.</br>
 也可以使用命令 `xray uuid` 生成随机的UUID. 
 
 {{% notice dark %}} `level`: number{{% /notice %}}

--- a/content/config/outbound-protocols/vless.md
+++ b/content/config/outbound-protocols/vless.md
@@ -98,7 +98,7 @@ VLESS 的用户 ID，可以是任意小于30字节的字符串, 也可以是一�
  
 其映射标准在[VLESS UUID 映射标准：将自定义字符串映射为一个 UUIDv5](https://github.com/XTLS/Xray-core/issues/158)
 
-你可以使用命令 `xray uuid -map "自定义字符串"` 生成自定义字符串所映射的的 UUID.</br> 
+你可以使用命令 `xray uuid -i "自定义字符串"` 生成自定义字符串所映射的的 UUID.</br>
 也可以使用命令 `xray uuid` 生成随机的UUID. 
 
 {{% notice dark %}} `encryption`: "none"{{% /notice %}}

--- a/content/config/outbound-protocols/vmess.md
+++ b/content/config/outbound-protocols/vmess.md
@@ -91,7 +91,7 @@ Vmess 的用户 ID，可以是任意小于30字节的字符串, 也可以是一�
  
 其映射标准在[VLESS UUID 映射标准：将自定义字符串映射为一个 UUIDv5](https://github.com/XTLS/Xray-core/issues/158)
 
-你可以使用命令 `xray uuid -map "自定义字符串"` 生成自定义字符串所映射的的 UUID.</br> 
+你可以使用命令 `xray uuid -i "自定义字符串"` 生成自定义字符串所映射的的 UUID.</br>
 也可以使用命令 `xray uuid` 生成随机的UUID. 
 
 {{% notice dark %}} `alterId`：number{{% /notice %}}


### PR DESCRIPTION
根据[Xray-core v1.2.2的更新说明](https://github.com/XTLS/Xray-core/releases/tag/v1.2.2)以及实际测试，修正`xray uuid -map "自定义字符串"`为`xray uuid -i "自定义字符串"`